### PR TITLE
Improve regex performance

### DIFF
--- a/src/date_time_tuple.rs
+++ b/src/date_time_tuple.rs
@@ -55,7 +55,8 @@ impl FromStr for DateTimeTuple {
     /// Expects a string formatted like one obtained by calling `DateTimeTuple.to_string()`
     fn from_str(s: &str) -> Result<DateTimeTuple, Self::Err> {
         lazy_static! {
-            static ref VALID_FORMAT: Regex = Regex::new(r"^\d{4}-\d{2}-\d{2}@\d{2}:\d{2}:\d{2}$").unwrap();
+            static ref VALID_FORMAT: Regex =
+                Regex::new(r"^\d{4}-\d{2}-\d{2}@\d{2}:\d{2}:\d{2}$").unwrap();
             static ref LEGACY_FORMAT: Regex = Regex::new(r"^\d{8}@\d{2}:\d{2}:\d{2}$").unwrap();
         }
 

--- a/src/date_time_tuple.rs
+++ b/src/date_time_tuple.rs
@@ -54,9 +54,12 @@ impl FromStr for DateTimeTuple {
 
     /// Expects a string formatted like one obtained by calling `DateTimeTuple.to_string()`
     fn from_str(s: &str) -> Result<DateTimeTuple, Self::Err> {
-        let valid_format = Regex::new(r"^\d{4}-\d{2}-\d{2}@\d{2}:\d{2}:\d{2}$").unwrap();
-        let legacy_format = Regex::new(r"^\d{8}@\d{2}:\d{2}:\d{2}$").unwrap();
-        if valid_format.is_match(s) || legacy_format.is_match(s) {
+        lazy_static! {
+            static ref VALID_FORMAT: Regex = Regex::new(r"^\d{4}-\d{2}-\d{2}@\d{2}:\d{2}:\d{2}$").unwrap();
+            static ref LEGACY_FORMAT: Regex = Regex::new(r"^\d{8}@\d{2}:\d{2}:\d{2}$").unwrap();
+        }
+
+        if VALID_FORMAT.is_match(s) || LEGACY_FORMAT.is_match(s) {
             let mut parts = s.split('@');
             let date_part = match DateTuple::from_str(parts.next().unwrap()) {
                 Ok(d) => d,

--- a/src/date_tuple.rs
+++ b/src/date_tuple.rs
@@ -274,11 +274,14 @@ impl FromStr for DateTuple {
 
     /// Expects a string formatted like 2018-11-02.
     ///
-    /// Also accepts the legacy crate format of 2018-11-02.
+    /// Also accepts the legacy crate format of 20181102.
     fn from_str(s: &str) -> Result<DateTuple, Self::Err> {
-        let valid_format = Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap();
-        let legacy_format = Regex::new(r"^\d{8}$").unwrap();
-        if valid_format.is_match(s) {
+        lazy_static! {
+            static ref VALID_FORMAT: Regex = Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap();
+            static ref LEGACY_FORMAT: Regex = Regex::new(r"^\d{8}$").unwrap();
+        }
+
+        if VALID_FORMAT.is_match(s) {
             match DateTuple::new(
                 u16::from_str(&s[0..4]).unwrap(),
                 u8::from_str(&s[5..7]).unwrap(),
@@ -287,7 +290,7 @@ impl FromStr for DateTuple {
                 Ok(d) => Ok(d),
                 Err(e) => Err(format!("Invalid date passed to from_str: {}", e)),
             }
-        } else if legacy_format.is_match(s) {
+        } else if LEGACY_FORMAT.is_match(s) {
             let (s1, s2) = s.split_at(4);
             let (s2, s3) = s2.split_at(2);
             match DateTuple::new(

--- a/src/date_utils.rs
+++ b/src/date_utils.rs
@@ -11,7 +11,7 @@ lazy_static! {
 
 /// Takes a year as a u16 and returns whether it is a leap year.
 pub fn is_leap_year(year: u16) -> bool {
-    (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0))
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 }
 
 /// Produces the integer representing the last date in the month in year.

--- a/src/month_tuple.rs
+++ b/src/month_tuple.rs
@@ -160,7 +160,7 @@ impl FromStr for MonthTuple {
             static ref VALID_FORMAT: Regex = Regex::new(r"^\d{4}-\d{2}$").unwrap();
             static ref LEGACY_FORMAT: Regex = Regex::new(r"^\d{6}$").unwrap();
         }
-        
+
         if VALID_FORMAT.is_match(s) {
             match MonthTuple::new(
                 u16::from_str(&s[0..4]).unwrap(),

--- a/src/month_tuple.rs
+++ b/src/month_tuple.rs
@@ -156,9 +156,12 @@ impl FromStr for MonthTuple {
     type Err = String;
 
     fn from_str(s: &str) -> Result<MonthTuple, Self::Err> {
-        let valid_format = Regex::new(r"^\d{4}-\d{2}$").unwrap();
-        let legacy_format = Regex::new(r"^\d{6}$").unwrap();
-        if valid_format.is_match(s) {
+        lazy_static! {
+            static ref VALID_FORMAT: Regex = Regex::new(r"^\d{4}-\d{2}$").unwrap();
+            static ref LEGACY_FORMAT: Regex = Regex::new(r"^\d{6}$").unwrap();
+        }
+        
+        if VALID_FORMAT.is_match(s) {
             match MonthTuple::new(
                 u16::from_str(&s[0..4]).unwrap(),
                 u8::from_str(&s[5..7]).unwrap(),
@@ -166,7 +169,7 @@ impl FromStr for MonthTuple {
                 Ok(m) => Ok(m),
                 Err(e) => Err(format!("Invalid month passed to from_str: {}", e)),
             }
-        } else if legacy_format.is_match(s) {
+        } else if LEGACY_FORMAT.is_match(s) {
             let (s1, s2) = s.split_at(4);
             match MonthTuple::new(u16::from_str(s1).unwrap(), u8::from_str(s2).unwrap()) {
                 Ok(m) => Ok(m),

--- a/src/time_tuple.rs
+++ b/src/time_tuple.rs
@@ -146,8 +146,11 @@ impl FromStr for TimeTuple {
     type Err = String;
 
     fn from_str(s: &str) -> Result<TimeTuple, Self::Err> {
-        let valid_format = Regex::new(r"^\d{2}:\d{2}:\d{2}$").unwrap();
-        if !valid_format.is_match(s) {
+        lazy_static! {
+            static ref VALID_FORMAT: Regex = Regex::new(r"^\d{2}:\d{2}:\d{2}$").unwrap();
+        }
+
+        if !VALID_FORMAT.is_match(s) {
             Err(format!(
                 "Invalid str formatting of TimeTuple: {}\nExpects a string formatted like 08:30:05",
                 s
@@ -367,8 +370,10 @@ impl FromStr for Duration {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Duration, Self::Err> {
-        let valid_format = Regex::new(r"^\d+:\d{2}:\d{2}$").unwrap();
-        if !valid_format.is_match(s) {
+        lazy_static! {
+            static ref VALID_FORMAT: Regex = Regex::new(r"^\d+:\d{2}:\d{2}$").unwrap();
+        }
+        if !VALID_FORMAT.is_match(s) {
             Err(format!(
                 "Invalid str formatting of Duration: {}\nExpects a string formatted like 8:30:05",
                 s


### PR DESCRIPTION
The current usage of Regex is very slow when used in a loop. Regex library docs tell us that compiling regex is quite [expensive](https://github.com/rust-lang/regex/blob/master/PERFORMANCE.md#thou-shalt-not-compile-regular-expressions-in-a-loop) and should not be done in a loop. I fixed the issue by using `lazy_static` to create the regex instances, as the docs recommend.

I measured the time of 1000 runs of `DateTuple::from_str()` with both implementations, and the one with `lazy_static` wins clearly:

- lazy_static: 5ms
- old: 4300ms

Also fixed typo in a comment.