### PR TITLE
Derive `Hash`, and serde's `Serialize` and `Deserialize` for `DateTuple`, `MonthTuple`, `TimeTuple` and `DateTimeTuple`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ coveralls = { repository = "notquiteamonad/date_time", branch = "master", servic
 [dependencies]
 regex = "1.1.6"
 lazy_static = "1.3.0"
+serde = { version = "^1.0", features = ["derive"], optional = true }
+
+[features]
+default = []
+serde_support = ["serde"]

--- a/src/date_time_tuple.rs
+++ b/src/date_time_tuple.rs
@@ -5,11 +5,13 @@ use std::fmt;
 use std::str::FromStr;
 use time_tuple::TimeTuple;
 
+
 pub type DateTime = DateTimeTuple;
 
 /// Wrapper for a specific date and time.
 ///
 /// Comprised of a DateTuple and a TimeTuple.
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct DateTimeTuple {
     d: DateTuple,

--- a/src/date_time_tuple.rs
+++ b/src/date_time_tuple.rs
@@ -5,13 +5,15 @@ use std::fmt;
 use std::str::FromStr;
 use time_tuple::TimeTuple;
 
-
 pub type DateTime = DateTimeTuple;
 
 /// Wrapper for a specific date and time.
 ///
 /// Comprised of a DateTuple and a TimeTuple.
-#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct DateTimeTuple {
     d: DateTuple,

--- a/src/date_time_tuple.rs
+++ b/src/date_time_tuple.rs
@@ -10,7 +10,7 @@ pub type DateTime = DateTimeTuple;
 /// Wrapper for a specific date and time.
 ///
 /// Comprised of a DateTuple and a TimeTuple.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct DateTimeTuple {
     d: DateTuple,
     t: TimeTuple,

--- a/src/date_tuple.rs
+++ b/src/date_tuple.rs
@@ -13,6 +13,7 @@ pub type Date = DateTuple;
 /// Holds a specific date by year, month, and day.
 ///
 /// Handles values from 01 Jan 0000 to 31 Dec 9999.
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct DateTuple {
     y: u16,

--- a/src/date_tuple.rs
+++ b/src/date_tuple.rs
@@ -13,7 +13,7 @@ pub type Date = DateTuple;
 /// Holds a specific date by year, month, and day.
 ///
 /// Handles values from 01 Jan 0000 to 31 Dec 9999.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct DateTuple {
     y: u16,
     m: u8,

--- a/src/date_tuple.rs
+++ b/src/date_tuple.rs
@@ -13,7 +13,10 @@ pub type Date = DateTuple;
 /// Holds a specific date by year, month, and day.
 ///
 /// Handles values from 01 Jan 0000 to 31 Dec 9999.
-#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct DateTuple {
     y: u16,

--- a/src/month_tuple.rs
+++ b/src/month_tuple.rs
@@ -17,6 +17,7 @@ pub type Month = MonthTuple;
 /// **NOTE:** MonthTuple's `m` field is one-based (one represents January) as of version 2.0.0.
 ///
 /// Only handles values between Jan 0000 and Dec 9999 (inclusive).
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct MonthTuple {
     y: u16,

--- a/src/month_tuple.rs
+++ b/src/month_tuple.rs
@@ -17,7 +17,7 @@ pub type Month = MonthTuple;
 /// **NOTE:** MonthTuple's `m` field is one-based (one represents January) as of version 2.0.0.
 ///
 /// Only handles values between Jan 0000 and Dec 9999 (inclusive).
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct MonthTuple {
     y: u16,
     m: u8,

--- a/src/month_tuple.rs
+++ b/src/month_tuple.rs
@@ -17,7 +17,10 @@ pub type Month = MonthTuple;
 /// **NOTE:** MonthTuple's `m` field is one-based (one represents January) as of version 2.0.0.
 ///
 /// Only handles values between Jan 0000 and Dec 9999 (inclusive).
-#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct MonthTuple {
     y: u16,

--- a/src/time_tuple.rs
+++ b/src/time_tuple.rs
@@ -17,6 +17,7 @@ pub type TimeOfDay = TimeTuple;
 /// **NOTE:** This cannot be 24 hours or greater - see `TimeTuple::new()` for more details.
 ///
 /// The wrapping described in `TimeTuple::new()` also applies when adding and subtracting times.
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct TimeTuple {
     h: u8,

--- a/src/time_tuple.rs
+++ b/src/time_tuple.rs
@@ -17,7 +17,10 @@ pub type TimeOfDay = TimeTuple;
 /// **NOTE:** This cannot be 24 hours or greater - see `TimeTuple::new()` for more details.
 ///
 /// The wrapping described in `TimeTuple::new()` also applies when adding and subtracting times.
-#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct TimeTuple {
     h: u8,

--- a/src/time_tuple.rs
+++ b/src/time_tuple.rs
@@ -17,7 +17,7 @@ pub type TimeOfDay = TimeTuple;
 /// **NOTE:** This cannot be 24 hours or greater - see `TimeTuple::new()` for more details.
 ///
 /// The wrapping described in `TimeTuple::new()` also applies when adding and subtracting times.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub struct TimeTuple {
     h: u8,
     m: u8,


### PR DESCRIPTION
The serde support is disabled by default, and behind the feature `serde_support`